### PR TITLE
Implement mouse event stream pausing

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,7 @@
 const mouseEvents = require("./index");
 
+let paused = false;
+
 mouseEvents.on("mouseup", data => {
   console.log(data);
 });
@@ -17,5 +19,21 @@ mouseEvents.on("mousewheel", data => {
 });
 
 setInterval(() => {
-  console.log("Still listening...");
+  if (!paused) {
+    console.error("Still listening...");
+  }
 }, 5000);
+
+process.on("SIGBREAK", () => {
+  if (paused) {
+    console.error("resuming mouse events");
+    mouseEvents.resumeMouseEvents();
+    paused = false;
+  } else {
+    console.error("pausing mouse events");
+    mouseEvents.pauseMouseEvents();
+    paused = true;
+  }
+});
+
+console.error("Press Ctrl+Break to toggle listening");

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,6 @@ import EventEmitter from 'events';
 
 export default new (class MouseEvents extends EventEmitter {
     constructor();
+    pauseMouseEvents(): boolean;
+    resumeMouseEvents(): boolean;
 })()

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ class MouseEvents extends EventEmitter {
                     }
                     this.emit(event, payload);
                 });
+                if (createdListener) {
+                    this.resumeMouseEvents();
+                }
             } else {
                 return;
             }

--- a/index.js
+++ b/index.js
@@ -46,8 +46,18 @@ class MouseEvents extends EventEmitter {
                 return;
 
             registeredEvents = registeredEvents.filter(x => x !== event);
+            if (event === "mousemove") {
+                addon.disableMouseMove();
+            }
         });
+    }
 
+    pauseMouseEvents() {
+        return addon.pauseMouseEvents();
+    }
+
+    resumeMouseEvents() {
+        return addon.resumeMouseEvents();
     }
 }
 


### PR DESCRIPTION
This can be used to reduce CPU usage: when you don't want any mouse events, you can explicitly pause the event stream.

For backwards compatibility, the stream of mouse events is still unpaused whenever a listener is first installed, but can be paused separately afterwards.